### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+For normative changes, the following tasks have been completed:
+ * [ ] At least two implementers are interested:
+   * …
+   * …
+ * [ ] Editing WG resolution on the proposed changes
+
+Implementation bugs are filed:
+ * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
+ * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
+ * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


### PR DESCRIPTION
This PR introduces a PR template that all subsequent changes into this repo should use, as per resolution to https://github.com/w3c/editing/issues/463. Once finalized, this template will be added to other Editing WG repos as well.